### PR TITLE
switch to navigator.mediaDevices.getUserMedia

### DIFF
--- a/janus.js
+++ b/janus.js
@@ -296,7 +296,7 @@ Janus.init = function(options) {
 // Helper method to check whether WebRTC is supported by this browser
 Janus.isWebrtcSupported = function() {
 	return window.RTCPeerConnection !== undefined && window.RTCPeerConnection !== null &&
-		navigator.getUserMedia !== undefined && navigator.getUserMedia !== null;
+		navigator.mediaDevices.getUserMedia !== undefined && navigator.mediaDevices.getUserMedia !== null;
 };
 
 // Helper method to create random identifiers (e.g., transaction)


### PR DESCRIPTION
`navigator.getUserMedia` is deprecated and Firefox returns undefined.

Switch to `navigator.mediaDevices.getUserMedia`, since that is what the rest of the code uses.